### PR TITLE
Allow --help for scripts

### DIFF
--- a/example/scripts/test.py
+++ b/example/scripts/test.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 import time
+import argparse
+
+# Supports subcommand help messages
+parser = argparse.ArgumentParser(description="Run tests")
+
+args = parser.parse_args()
 
 start = time.time()
 

--- a/index.js
+++ b/index.js
@@ -92,7 +92,12 @@ async function scritch(dir, opts = {}) {
     help += stripIndent(helpContent).trimRight()
   }
 
-  let cli = meow({ argv, pkg, help })
+  let cli = meow({ 
+    argv, 
+    pkg, 
+    help,
+    autoHelp: false, 
+  })
 
   // Match script being run
   let scriptName = cli.input[0]


### PR DESCRIPTION
scritch's meow is currently eating --help flags.

If you run `company-cli test --help` it shows the `company-cli` usage.

This PR fixes that by turning off `autoHelp`. scritch's usage still appears if no script is passed.
