### PR TITLE
Exclude index.js as script

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function scritch(dir, opts = {}) {
     }
 
     // Ignore scripts that start with `_` (treated like helpers)
-    if (dirent.name.startsWith('_')) {
+    if (dirent.name.startsWith('_') || dirent.name === 'index.js') {
       continue
     }
 


### PR DESCRIPTION
if you load `scritch` from an `index.js` file inside your scripts directory, it will not be considered a script.